### PR TITLE
docs: fix stale clone URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The escrow and its ERC-3009 token collector are not natively deployed on Arc Tes
 
 1. Clone the repository and install dependencies:
   ```bash
-   git clone https://github.com/akelani-circle/arc-ecommerce-payments.git
+   git clone https://github.com/circlefin/arc-ecommerce-payments.git
    cd arc-ecommerce-payments
    npm install
   ```


### PR DESCRIPTION
The Getting Started section pointed `git clone` at a developer's personal fork (`akelani-circle/arc-ecommerce-payments`) instead of the official Circle org. This corrects the URL to `circlefin/arc-ecommerce-payments` so new users clone from the canonical repo.

Same stale `akelani-circle` clone URL found while sweeping per circlefin/arc-p2p-payments#10.