### PR TITLE
fix: validate checkout token amounts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   check:
-    name: Type-check, lint & build
+    name: Type-check, test, lint & build
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -31,6 +31,9 @@ jobs:
 
       - name: Type-check
         run: npx tsc --noEmit
+
+      - name: Test
+        run: npm test
 
       - name: Lint
         run: npm run lint

--- a/app/api/checkout/intent/route.ts
+++ b/app/api/checkout/intent/route.ts
@@ -17,11 +17,12 @@
  */
 
 import { NextResponse } from "next/server";
-import { isAddress, parseUnits, type Address } from "viem";
+import { isAddress, type Address } from "viem";
 import { tokenFor } from "@/lib/arc/tokens";
 import { escrowAddress, tokenCollectorAddress } from "@/lib/contracts";
 import { buildPaymentInfo } from "@/lib/payments/payment-info";
 import { payerAgnosticNonce } from "@/lib/payments/authorization";
+import { parsePositiveTokenAmount } from "@/lib/payments/token-amount";
 import { putIntent, type OrderLineItem } from "@/lib/payments/intent-store";
 import { operatorAddress, merchantReceiver } from "@/lib/operator/config";
 import type { Currency } from "@/lib/products";
@@ -69,8 +70,11 @@ export async function POST(req: Request) {
   if (!payer || !isAddress(payer)) {
     return NextResponse.json({ error: "Invalid payer address" }, { status: 400 });
   }
-  const total = Number(amount);
-  if (!amount || !Number.isFinite(total) || total <= 0) {
+  const token = tokenFor(currency as Currency);
+  const parsedAmount = amount
+    ? parsePositiveTokenAmount(amount, token.decimals)
+    : null;
+  if (!parsedAmount) {
     return NextResponse.json({ error: "Invalid amount" }, { status: 400 });
   }
   const items = parseItems(body.items);
@@ -78,8 +82,7 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: "Invalid cart items" }, { status: 400 });
   }
 
-  const token = tokenFor(currency as Currency);
-  const maxAmount = parseUnits(amount, token.decimals);
+  const maxAmount = parsedAmount.units;
 
   const paymentInfo = buildPaymentInfo({
     operator: operatorAddress(),
@@ -93,7 +96,7 @@ export async function POST(req: Request) {
   putIntent(nonce, {
     paymentInfo,
     currency: currency as Currency,
-    total,
+    total: parsedAmount.display,
     items,
   });
 

--- a/lib/payments/token-amount.ts
+++ b/lib/payments/token-amount.ts
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2026 Circle Internet Group, Inc.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { formatUnits, parseUnits } from "viem";
+
+export type ParsedTokenAmount = {
+  units: bigint;
+  display: number;
+};
+
+/** Parse a positive, plain-decimal token amount without rounding it. */
+export function parsePositiveTokenAmount(
+  value: string,
+  decimals: number,
+): ParsedTokenAmount | null {
+  if (!Number.isInteger(decimals) || decimals < 0) return null;
+
+  const fraction = decimals > 0 ? `(?:\\.\\d{1,${decimals}})?` : "";
+  const decimalPattern = new RegExp(`^(?:0|[1-9]\\d*)${fraction}$`);
+  if (!decimalPattern.test(value)) return null;
+
+  const units = parseUnits(value, decimals);
+  if (units <= BigInt(0)) return null;
+
+  const display = Number(formatUnits(units, decimals));
+  if (!Number.isFinite(display)) return null;
+
+  return { units, display };
+}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "test": "node --import tsx --test test/token-amount.test.ts",
     "db:start": "supabase start",
     "db:stop": "supabase stop",
     "db:status": "supabase status",

--- a/test/token-amount.test.ts
+++ b/test/token-amount.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2026 Circle Internet Group, Inc.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { parsePositiveTokenAmount } from "../lib/payments/token-amount";
+
+describe("parsePositiveTokenAmount", () => {
+  it("parses positive decimal amounts exactly", () => {
+    assert.deepEqual(parsePositiveTokenAmount("1", 6), {
+      units: BigInt(1_000_000),
+      display: 1,
+    });
+    assert.deepEqual(parsePositiveTokenAmount("1.250000", 6), {
+      units: BigInt(1_250_000),
+      display: 1.25,
+    });
+    assert.deepEqual(parsePositiveTokenAmount("0.000001", 6), {
+      units: BigInt(1),
+      display: 0.000001,
+    });
+  });
+
+  it("rejects values that would be rounded or fail parseUnits", () => {
+    for (const value of [
+      "1e3",
+      "0.0000001",
+      "1.0000001",
+      " 1",
+      "1 ",
+      "+1",
+      ".5",
+      "1.",
+    ]) {
+      assert.equal(parsePositiveTokenAmount(value, 6), null, value);
+    }
+  });
+
+  it("rejects empty and non-positive amounts", () => {
+    for (const value of ["", "0", "0.000000"]) {
+      assert.equal(parsePositiveTokenAmount(value, 6), null, value);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- validate checkout amounts as positive plain decimals within the selected token's precision
- return a `400` response for unsupported formats instead of letting `parseUnits` throw or round the value
- add focused Node test coverage and run it in CI

## Why

`POST /api/checkout/intent` first coerced the amount with `Number()` and then passed the original string to `parseUnits()`. Values such as `1e3` passed the numeric check but caused `parseUnits()` to throw, producing an unhandled server error. Values beyond the token's six-decimal precision could also be rounded instead of rejected.

The new parser accepts only positive plain-decimal values that can be represented exactly by the token.

## Testing

- `npm test`
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build`