### PR TITLE
fix(webhooks): require HMAC verification before order mutations

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ curl -X POST https://api.circle.com/v1/w3s/contracts/event-monitors \
   }'
 ```
 
-Set `WEBHOOK_SECRET=<your-WEBHOOK_SECRET>` in `.env.local`, then uncomment the HMAC-SHA256 signature verification block at the top of `app/api/webhooks/payments/route.ts`. Circle signs each push request with the shared secret; the handler verifies it before processing.
+Set `WEBHOOK_SECRET=<your-WEBHOOK_SECRET>` in `.env.local`. Circle signs each push request with the shared secret; the handler verifies `x-scp-signature` (HMAC-SHA256) before processing and returns `503` if the secret is unset.
 
 ## **Legal disclaimer**
 

--- a/app/api/webhooks/payments/route.ts
+++ b/app/api/webhooks/payments/route.ts
@@ -60,6 +60,7 @@
  * for when the escrow contract is registered with SCP event monitoring.
  */
 
+import { createHmac, timingSafeEqual } from "crypto";
 import { NextRequest, NextResponse } from "next/server";
 import { createServiceClient } from "@/lib/supabase/service";
 
@@ -111,23 +112,40 @@ function toTokenUnits(raw: string | undefined): number | undefined {
   return Number(raw) / 1_000_000;
 }
 
+function verifyWebhookSignature(
+  rawBody: string,
+  signature: string,
+  secret: string,
+): boolean {
+  const expected = createHmac("sha256", secret).update(rawBody).digest("hex");
+  const a = Buffer.from(signature);
+  const b = Buffer.from(expected);
+  // timingSafeEqual throws on length mismatch; treat as invalid.
+  return a.length === b.length && timingSafeEqual(a, b);
+}
+
 // --- Webhook handler ---
 
 export async function POST(req: NextRequest): Promise<NextResponse> {
-  // Signature verification (uncomment once WEBHOOK_SECRET is set in env).
-  // const secret = process.env.WEBHOOK_SECRET;
-  // if (secret) {
-  //   const sig = req.headers.get("x-scp-signature") ?? "";
-  //   const body = await req.text();
-  //   const expected = createHmac("sha256", secret).update(body).digest("hex");
-  //   if (!timingSafeEqual(Buffer.from(sig), Buffer.from(expected))) {
-  //     return NextResponse.json({ error: "invalid signature" }, { status: 401 });
-  //   }
-  // }
+  // Fail closed: this handler uses the service-role Supabase client to mutate
+  // order lifecycle state. Unsigned requests must never reach that path.
+  const secret = process.env.WEBHOOK_SECRET;
+  if (!secret) {
+    return NextResponse.json(
+      { error: "webhook secret not configured" },
+      { status: 503 },
+    );
+  }
+
+  const rawBody = await req.text();
+  const signature = req.headers.get("x-scp-signature") ?? "";
+  if (!verifyWebhookSignature(rawBody, signature, secret)) {
+    return NextResponse.json({ error: "invalid signature" }, { status: 401 });
+  }
 
   let payload: ScpWebhookPayload;
   try {
-    payload = (await req.json()) as ScpWebhookPayload;
+    payload = JSON.parse(rawBody) as ScpWebhookPayload;
   } catch {
     return NextResponse.json({ error: "invalid JSON" }, { status: 400 });
   }


### PR DESCRIPTION
## Summary
`POST /api/webhooks/payments` drives order lifecycle (`Paid` / `Refunded` / `Canceled` / …) through the **Supabase service-role** client, but HMAC verification was left commented out:

```ts
// Signature verification (uncomment once WEBHOOK_SECRET is set in env).
// const secret = process.env.WEBHOOK_SECRET;
// if (secret) { … }
```

That is fail-open: any caller who can reach the endpoint and supply a payment `salt` can forge lifecycle transitions without `WEBHOOK_SECRET`. README already lists `WEBHOOK_SECRET` as required setup and documents SCP signing.

This PR:
1. Returns `503` when `WEBHOOK_SECRET` is unset (fail closed)
2. Verifies `x-scp-signature` as HMAC-SHA256 over the raw body with length-checked `timingSafeEqual`
3. Parses JSON only after verification
4. Updates README (no more “uncomment the block”)

Operator routes that write order status without SCP remain unchanged.

## Test plan
- [ ] With `WEBHOOK_SECRET` unset → `503`
- [ ] With secret set, wrong/missing `x-scp-signature` → `401`
- [ ] With valid HMAC over body → existing salt lookup / status patch path unchanged
- [ ] `npm run lint` on touched file


Made with [Cursor](https://cursor.com)