### PR TITLE
fix(security): sanitize control characters and whitespace in safeRedirect to prevent open redirects

### DIFF
--- a/lib/safe-redirect.ts
+++ b/lib/safe-redirect.ts
@@ -26,7 +26,10 @@ export function safeRedirect(
   raw: string | null | undefined,
   fallback = "/account",
 ): string {
-  if (!raw || !raw.startsWith("/")) return fallback;
-  if (raw.startsWith("//") || raw.startsWith("/\\")) return fallback;
-  return raw;
+  if (!raw) return fallback;
+  const cleaned = raw.trim().replace(/[\r\n\t\0]/g, "");
+  if (!cleaned.startsWith("/") || cleaned.startsWith("//") || cleaned.startsWith("/\\")) {
+    return fallback;
+  }
+  return cleaned;
 }


### PR DESCRIPTION
Updated safeRedirect in lib/safe-redirect.ts to trim whitespace and strip control characters (\r, \n, \t, \0) before checking path prefixes. Previously, smuggled control characters in redirect URLs (such as /\r/evil.com) bypassed the // prefix check while resolving to protocol-relative external URLs in browsers.